### PR TITLE
Update CMake files to match the current code. Fix time and compiler bugs.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "cppdbg",
             "request": "launch",
             "preLaunchTask": "C/C++: g++.exe build active file",
-            "program": "${workspaceFolder}/src/demonstration/main.exe",
+            "program": "${workspaceFolder}/src/demonstration/rk_logger_demonstration.exe",
             "args": [],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}/src/demonstration",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,7 +14,7 @@
                 "-I",
                 "${workspaceFolder}/src/demonstration",
                 "-o",
-                "${workspaceFolder}/src/demonstration/main.exe"
+                "${workspaceFolder}/src/demonstration/rk_logger_demonstration.exe"
             ],
             "options": {
                 "cwd": "${fileDirname}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,5 +3,10 @@ project(rk_logger)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED true)
 
-add_library(rk_logger ${PROJECT_SOURCE_DIR}/src/log.cpp)
-target_include_directories(rk_logger PRIVATE ${PROJECT_SOURCE_DIR}/include)
+set(RK_LOGGER_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR} CACHE PATH "The root-level of the RK Logger project")
+
+file(GLOB SOURCES ${RK_LOGGER_SOURCE_DIR}/src/*.cpp)
+add_library(rk_logger STATIC ${SOURCES})
+target_include_directories(rk_logger PUBLIC ${RK_LOGGER_SOURCE_DIR}/include)
+
+add_subdirectory(${RK_LOGGER_SOURCE_DIR}/src/demonstration)

--- a/src/demonstration/main.cpp
+++ b/src/demonstration/main.cpp
@@ -45,15 +45,15 @@ int main() {
     // Generate some random events
     std::random_device rd;
     std::mt19937 gen(rd());
-    size_t randomDuration;
+    double randomDuration;
     constexpr size_t MAX_RANDOM_EVENTS = 15;
     size_t randomEventsCount = 0;
-    std::thread randomEvents([&gen, &randomDuration, &randomEventsCount] () {
+    std::thread randomEvents([&gen, &randomDuration, &randomEventsCount, &MAX_RANDOM_EVENTS] () {
         while (randomEventsCount < MAX_RANDOM_EVENTS) {
-            std::uniform_int_distribution<> dist(0, 5);
+            std::uniform_real_distribution<> dist(0, 5);
             randomDuration = dist(gen);
             RK_LOG("Random event happened. Printing a log for it. Random events remaining: ", MAX_RANDOM_EVENTS - randomEventsCount, "\n");
-            std::this_thread::sleep_for(std::chrono::seconds(randomDuration));
+            std::this_thread::sleep_for(std::chrono::duration<double>(randomDuration));
             randomEventsCount++;
         }
     });

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -19,7 +19,6 @@ std::thread startLogger(const std::filesystem::path& configPath) {
     rk::config::getLoggingConfig(configPath);
     rk::time::updateTimeStampFuncs();
 
-    // Create a log file with a time stamp
     std::string timeStamp = rk::time::generateTimeStamp(rk::time::system_clock::now());
     timeStamp = rk::time::convertTimeStampForFileName(timeStamp);
     const std::string logFileName = std::string("logs_") + timeStamp + ".txt";

--- a/src/log_config.cpp
+++ b/src/log_config.cpp
@@ -10,15 +10,17 @@
 namespace rk {
 namespace config {
 
+// The values are explicitly casted to uint8_t in order to supress compiler warnings
 PossibleValuesMap dateFormatPossibleValues = {
-    { "MM_DD_YYYY", 0u }, // i.e., Feb 4, 2025 is formatted as [02|Feb]-04-2025
-    { "DD_MM_YYYY", 1u }, // i.e., Feb 4, 2025 is formatted as 04-[02|Feb]-2025
-    { "YYYY_MM_DD", 2u } // i.e., Feb 4, 2025 is formatted as 2025-[02|Feb]-04
+    { "MM_DD_YYYY", static_cast<uint8_t>(0u) }, // i.e., Feb 4, 2025 is formatted as [02|Feb]-04-2025
+    { "DD_MM_YYYY", static_cast<uint8_t>(1u) }, // i.e., Feb 4, 2025 is formatted as 04-[02|Feb]-2025
+    { "YYYY_MM_DD", static_cast<uint8_t>(2u) } // i.e., Feb 4, 2025 is formatted as 2025-[02|Feb]-04
 };
 
+// The values are explicitly casted to uint8_t in order to supress compiler warnings
 PossibleValuesMap monthFormatPossibleValues = {
-    { "MONTH_NUM", 0u }, // Prints the months name, e.g., Jan, Feb, etc.
-    { "MONTH_NAME", 1u } // Prints the month's number, e.g., 01, 02, etc.
+    { "MONTH_NUM", static_cast<uint8_t>(0u) }, // Prints the months name, e.g., Jan, Feb, etc.
+    { "MONTH_NAME", static_cast<uint8_t>(1u) } // Prints the month's number, e.g., 01, 02, etc.
 };
 
 ConfigMap configMap = {


### PR DESCRIPTION
* Update CMake files to match the current code.
* Allow fractional times for random events in the demo.
* Explicitly cast some uint8_t values to supress compiler warnings.
* Fix milliseconds not being calculated correctly for varying std::chrono periods.