### PR TITLE
Rename endLoop variable to be more precise. Update comments.

### DIFF
--- a/include/rk_logger/log_time.h
+++ b/include/rk_logger/log_time.h
@@ -34,14 +34,14 @@ constexpr const char* months[12] = {
 };
 
 /**
- * @brief Generates a time-stamp from a time_point.
+ * @brief Generates a timestamp from a time_point.
  * 
  * @param time_point The time_point to convert.
  */
 std::string generateTimeStamp(time_point);
 
 /**
- * @brief Converts a month number to the english name.
+ * @brief Converts a month number to the abbreviated English name.
  * 
  * It starts at 1 and goes up, so January = 1, February = 2, etc.
  * 
@@ -53,12 +53,10 @@ std::string monthNumToName(const uint8_t);
 /**
  * @brief Adds zeros to the beginning of a number to make it have a specific number of characters.
  * 
- * This is meant for keeping the time stamps uniform in size.
- * 
  * @param std::string The number to modify.
- * @param size_t The target size to change it to.
+ * @param int The target size to change it to.
  */
-void padWithZeros(std::string&, const size_t);
+void padWithZeros(std::string&, const int);
 
 /**
  * @brief Converts a time stamp in order to use it in a file name.
@@ -106,7 +104,7 @@ extern std::function<std::string(const std::string, const std::string, const std
 extern std::function<std::string(std::string, const std::string, const std::string, const std::string)> timeFunc;
 
 /**
- * @brief Updates the month function. This function does not "update the month", but rather updates the function that formats the month.
+ * @brief Updates the month function. This function itself does not "update the month", but rather updates the function that formats the month.
  */
 void updateMonthFunc();
 

--- a/include/rk_logger/logger.h
+++ b/include/rk_logger/logger.h
@@ -1,6 +1,6 @@
 /**
  * @file log.h
- * @brief The header file for the logger.
+ * @brief Header for the logger.
  * 
  * This file contains functions, macros, and variables that are used by the logger. See the demonstration directory
  * for an example of its use. Also, see the README for an overview.
@@ -46,7 +46,7 @@ namespace log {
 extern std::mutex logQueueMutex; 
 extern std::queue<std::string> logQueue; /**< Main queue for holding log messages */ 
 extern std::mutex endLoopMtx;
-extern bool endLoop; /**< Determines whether or not to end the log loop */ 
+extern bool endLogLoop;
 extern std::ofstream logFile;
 extern std::condition_variable cv;
 
@@ -68,7 +68,7 @@ void stopLogger(std::thread);
 /**
  * @brief Adds a message to the log queue.
  * 
- * This function should not be called by itself. Call it via the LOG macro.
+ * This function should not be called by itself. Call it via the RK_LOG macro.
  * 
  * @param time The time that the message was logged.
  * @param funcName The function that this is being called from.

--- a/src/log_config.cpp
+++ b/src/log_config.cpp
@@ -51,7 +51,7 @@ void getLoggingConfig(const std::filesystem::path& path) {
     std::cout << "Trying to open RK Logger config file at path " << path << "" << std::endl;
     std::ifstream configFile(path);
     if (!configFile) {
-        std::cout << "Could not open RK Logger config file. Either one wasn't provided or the path provided was wrong. Using default RK Logger config" << std::endl;
+        std::cout << "Could not open RK Logger config file. Either one wasn't provided or the path provided was invalid. Using default RK Logger config" << std::endl;
         return;
     }
     else {

--- a/src/log_time.cpp
+++ b/src/log_time.cpp
@@ -39,7 +39,7 @@ std::string generateTimeStamp(time_point time_point) {
 
     /**
      * Need to calculate milliseconds. Convert the current time to seconds in order to lose precision and lose
-     * the fractional portion. Then, subtract that number from the current time milliseconds and the difference
+     * the fractional portion. Then, subtract that number from the current time in milliseconds and the difference
      * should be the milliseconds portion of the current time.
      */
     auto time_point_as_ms = std::chrono::duration_cast<std::chrono::milliseconds>(time_point.time_since_epoch()).count();

--- a/src/log_time.cpp
+++ b/src/log_time.cpp
@@ -65,7 +65,7 @@ std::string monthNumToName(const uint8_t monthNum) {
     return months[monthNum - 1]; // Subtract one because the index of months array starts at 0
 }
 
-void padWithZeros(std::string& number, const size_t targetSize) {
+void padWithZeros(std::string& number, const int targetSize) {
     // If target size is 1, then no zeros need to be added, so just return. Same for empty numbers.
     if (number.empty() || targetSize < 2) {
         return;
@@ -208,7 +208,7 @@ void updateTimeFunc() {
 }
 
 void updateTimeStampFuncs() {
-    std::cout << "Updating time stamp functions\n";
+    std::cout << "Updating timestamp functions\n";
     updateMonthFunc();
     updateDateFunc();
     updateTimeFunc();

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -1,6 +1,6 @@
 /**
  * @file log.cpp
- * @brief The implementation file for the logger.
+ * @brief Source file for the logger.
  */
 #include "rk_logger/logger.h"
 
@@ -10,7 +10,7 @@ namespace log {
 std::mutex logQueueMutex;
 std::queue<std::string> logQueue;
 std::mutex endLoopMtx;
-bool endLoop;
+bool endLogLoop;
 std::ofstream logFile;
 std::condition_variable cv;
 
@@ -37,20 +37,20 @@ void stopLogger(std::thread logThread) {
 }
 
 /**
- * Checks whether the log queue has messages or the endLoop flag is true. If either are true, it will return true,
+ * Checks whether the log queue has messages or the endLogLoop flag is true. If either are true, it will return true,
  * stop the condition variable from waiting, and resume execution of the log loop. This should be called as part of
  * the log loop's condition variable, so the mutex for the log queue will be locked by the condition variable when
  * this function executes, so it doesn't need to be locked explicitly.
  */
 bool condVarPredicate() {
     std::unique_lock<std::mutex> endLoopLock(endLoopMtx);
-    return !logQueue.empty() || endLoop;
+    return !logQueue.empty() || endLogLoop;
 }
 
 /**
  * This function will continously check the log queue for new messages and print them via std::cout.
  * If no logs are in the queue, it'll wait until new ones get added.
- * It will end the loop once the endLoop flag is set to true and the queue is empty.
+ * It will end the loop once the endLogLoop flag is set to true and the queue is empty.
  */
 void logQueueLoop() {
     std::string msg;
@@ -67,7 +67,7 @@ void logQueueLoop() {
         }
         else {
             std::unique_lock<std::mutex> endLoopLock(endLoopMtx);
-            if (!endLoop) {
+            if (!endLogLoop) {
                 endLoopLock.unlock();
                 cv.wait(logLock, rk::log::condVarPredicate);
             }
@@ -78,22 +78,19 @@ void logQueueLoop() {
     }
 }
 
-/**
- * Creates the thread that will run the log loop function "logQueueLoop()".
- */
 std::thread startLogThread() {
     std::thread logThread(logQueueLoop);
     return logThread;
 }
 
 /**
- * Ends the log thread that was passed in by first setting the endLoop flag to
+ * Ends the log thread that was passed in by first setting the endLogLoop flag to
  * true. This will allow the log loop to exit. Then, it will join the thread.
  */
 void endLogThread(std::thread thread) {
     {
         std::lock_guard<std::mutex> lock(endLoopMtx);
-        endLoop = true;
+        endLogLoop = true;
         cv.notify_all();
     }
 
@@ -102,9 +99,6 @@ void endLogThread(std::thread thread) {
     }
 }
 
-/**
- * Closes the log file by using std::ofstream::close().
- */
 void closeLogFile() {
     logFile.close();
 }


### PR DESCRIPTION
`endLoop` was changed to `endLogLoop` to be more accurate in its naming. Made some minor updates to comments.