### PR TITLE
Add write to log file config setting. Update time stamp spelling to t…

### DIFF
--- a/include/rk_logger/log_config.h
+++ b/include/rk_logger/log_config.h
@@ -17,13 +17,21 @@ namespace config {
 const inline std::string CONFIG_FILE_NAME = "rk_config.txt";
 
 using PossibleValuesMap = const std::unordered_map<std::string, uint8_t>;
+namespace configFileKeys {
+    const std::string DATE_FORMAT = "date_format";
+    const std::string MONTH_FORMAT = "month_format";
+    const std::string TIME_FORMAT = "time_format";
+    const std::string WRITE_TO_LOG_FILE = "write_to_log_file";
+};
+
 extern PossibleValuesMap dateFormatPossibleValues;
 extern PossibleValuesMap monthFormatPossibleValues;
 extern PossibleValuesMap timeFormatPossibleValues;
+extern PossibleValuesMap writeToLogFilePossibleValues;
 
 using ActualValue = uint8_t; /**< The type of value that will be used for the Config setting */
 using ConfigMap = std::unordered_map<std::string, std::tuple<PossibleValuesMap, ActualValue>>;
-extern ConfigMap configMap; /**< Holds the current configuration along with other config-related info */
+extern ConfigMap configuration; /**< Holds the current configuration */
 
 /**
  * @brief Parses the logging config file and updates the settings based on the contents.

--- a/include/rk_logger/log_time.h
+++ b/include/rk_logger/log_time.h
@@ -53,7 +53,7 @@ std::string monthNumToName(const uint8_t);
 /**
  * @brief Adds zeros to the beginning of a number to make it have a specific number of characters.
  * 
- * This is meant for keeping the time stamps uniform in size.
+ * This is meant for keeping the timestamps uniform in size.
  * 
  * @param std::string The number to modify.
  * @param size_t The target size to change it to.
@@ -61,12 +61,12 @@ std::string monthNumToName(const uint8_t);
 void padWithZeros(std::string&, const size_t);
 
 /**
- * @brief Converts a time stamp in order to use it in a file name.
+ * @brief Converts a timestamp in order to use it in a file name.
  * 
- * It will remove any characters that are not allowed in a file name and format it for readability. Meant to be used with the output from the time stamp function.
+ * It will remove any characters that are not allowed in a file name and format it for readability. Meant to be used with the output from the timestamp function.
  * 
- * @param std::string The time stamp to convert.
- * @return The converted time stamp.
+ * @param std::string The timestamp to convert.
+ * @return The converted timestamp.
  */
 std::string convertTimeStampForFileName(const std::string);
 

--- a/include/rk_logger/logger.h
+++ b/include/rk_logger/logger.h
@@ -77,7 +77,7 @@ void stopLogger(std::thread);
 template<typename... Args>
 void logMessage(const rk::time::time_point time, const std::string funcName, const Args&... args) {
     std::ostringstream oss;
-    oss << rk::time::generateTimeStamp(time); // Prefix the time stamp
+    oss << rk::time::generateTimeStamp(time); // Prefix the timestamp
     oss << "[" << std::this_thread::get_id() << "][" << funcName << "]"; // Prefix the thread id and function name
     (oss << ... << args);
     std::lock_guard<std::mutex> lock(logQueueMutex);
@@ -111,6 +111,11 @@ std::thread startLogThread();
  * thread that was created in startLogThread().
  */
 void endLogThread(std::thread);
+
+/**
+ * @brief Opens the log file.
+ */
+void openLogFile();
 
 /**
  * @brief Closes the log file.

--- a/src/demonstration/rk_config.txt
+++ b/src/demonstration/rk_config.txt
@@ -1,31 +1,50 @@
 /**
  * This file contains settings that will modify the behavior of the logger. The logger will read the settings from this file during runtime.
  * This file is optional. If the logger cannot find this file, it will use the default settings.
+ * Each setting has its own section. Below the commented sections, update the setting to the desired value.
  */
 
 /**
- * Set the format of the date that will be prefixed to each log message. Choose one of the options below and set it to the date_format value.
+ * DATE FORMAT
+ *
+ * Sets the format of the date that will be prefixed to each log message.
  * 
- * MM_DD_YYYY i.e., Feb 4, 2025 is formatted as [02|Feb]-04-2025
- * DD_MM_YYYY i.e., Feb 4, 2025 is formatted as 04-[02|Feb]-2025
- * YYYY_MM_DD i.e., Feb 4, 2025 is formatted as 2025-[02|Feb]-04
+ * Possible values:
+ * "MM_DD_YYYY" i.e., Feb 4, 2025 is formatted as [02|Feb]-04-2025
+ * "DD_MM_YYYY" i.e., Feb 4, 2025 is formatted as 04-[02|Feb]-2025
+ * "YYYY_MM_DD" i.e., Feb 4, 2025 is formatted as 2025-[02|Feb]-04
  */
 date_format=MM_DD_YYYY
 
 /**
- * Set the format of the month that will be printed in the date that is prefixed to each log message. 
- * Choose one of the options below and set it to the month_format value.
+ * MONTH FORMAT
+ *
+ * Sets the format of the month that will be printed in the date that is prefixed to each log message.
  * 
- * MONTH_NUM i.e., month as a number, e.g., Jan, Feb, etc.
- * MONTH_NAME i.e., month as a name, e.g., 01, 02, etc.
+ * Possible values:
+ * "MONTH_NUM" i.e., month as a number, e.g., Jan, Feb, etc.
+ * "MONTH_NAME" i.e., month as a name, e.g., 01, 02, etc.
  */
 month_format=MONTH_NUM
 
 /**
- * Set the time format to be either 12-hour or 24-hour format. Choose one of the options below and set it
- * to the time_format value.
+ * TIME FORMAT
+ * 
+ * Sets the time format to be either 12-hour or 24-hour format.
  *
- * 12 e.g., 8:30PM becomes "08:30:00.000 PM"
- * 24 e.g., 8:30PM becomes "20:30:00.000"
+ * Possible values:
+ * "12" e.g., 8:30PM becomes "08:30:00.000 PM"
+ * "24" e.g., 8:30PM becomes "20:30:00.000"
  */
 time_format=12
+
+/**
+ * WRITE TO LOG FILE
+ * 
+ * Enables or disables writing log output to a file.
+ *
+ * Possible values:
+ * "enable"
+ * "disable"
+ */
+write_to_log_file=disable

--- a/src/demonstration/rk_config.txt
+++ b/src/demonstration/rk_config.txt
@@ -44,7 +44,7 @@ time_format=12
  * Enables or disables writing log output to a file.
  *
  * Possible values:
- * "enable"
- * "disable"
+ * "ENABLE"
+ * "DISABLE"
  */
-write_to_log_file=disable
+write_to_log_file=ENABLE

--- a/src/log_config.cpp
+++ b/src/log_config.cpp
@@ -29,10 +29,16 @@ PossibleValuesMap timeFormatPossibleValues = {
     { "24", static_cast<uint8_t>(1u) } // Uses 24-hour clock format, e.g., 8:30PM becomes "20:30:00.000"
 };
 
-ConfigMap configMap = {
-    { "date_format", std::make_tuple(dateFormatPossibleValues, dateFormatPossibleValues.at("MM_DD_YYYY")) },
-    { "month_format", std::make_tuple(monthFormatPossibleValues, monthFormatPossibleValues.at("MONTH_NUM")) },
-    { "time_format", std::make_tuple(timeFormatPossibleValues, timeFormatPossibleValues.at("12")) },
+PossibleValuesMap writeToLogFilePossibleValues = {
+    { "disable", static_cast<uint8_t>(0) },
+    { "enable", static_cast<uint8_t>(1) }
+};
+
+ConfigMap configuration = {
+    { configFileKeys::DATE_FORMAT, std::make_tuple(dateFormatPossibleValues, dateFormatPossibleValues.at("MM_DD_YYYY")) },
+    { configFileKeys::MONTH_FORMAT, std::make_tuple(monthFormatPossibleValues, monthFormatPossibleValues.at("MONTH_NUM")) },
+    { configFileKeys::TIME_FORMAT, std::make_tuple(timeFormatPossibleValues, timeFormatPossibleValues.at("12")) },
+    { configFileKeys::WRITE_TO_LOG_FILE, std::make_tuple(writeToLogFilePossibleValues, writeToLogFilePossibleValues.at("enable")) },
 };
 
 void getLoggingConfig(const std::filesystem::path& path) {
@@ -71,8 +77,8 @@ void getLoggingConfig(const std::filesystem::path& path) {
         const std::string configKey = line.substr(0, equalsIndex);
 
         // Check if the user-provided key is a valid logger setting
-        auto configKeyIter = rk::config::configMap.find(configKey);
-        if (configKeyIter == rk::config::configMap.end()) {
+        auto configKeyIter = rk::config::configuration.find(configKey);
+        if (configKeyIter == rk::config::configuration.end()) {
             std::cout << "Key \"" << configKey << "\" was not valid. Skipping" << std::endl;
             continue;
         }

--- a/src/log_config.cpp
+++ b/src/log_config.cpp
@@ -30,15 +30,15 @@ PossibleValuesMap timeFormatPossibleValues = {
 };
 
 PossibleValuesMap writeToLogFilePossibleValues = {
-    { "disable", static_cast<uint8_t>(0) },
-    { "enable", static_cast<uint8_t>(1) }
+    { "DISABLE", static_cast<uint8_t>(0) },
+    { "ENABLE", static_cast<uint8_t>(1) }
 };
 
 ConfigMap configuration = {
     { configFileKeys::DATE_FORMAT, std::make_tuple(dateFormatPossibleValues, dateFormatPossibleValues.at("MM_DD_YYYY")) },
     { configFileKeys::MONTH_FORMAT, std::make_tuple(monthFormatPossibleValues, monthFormatPossibleValues.at("MONTH_NUM")) },
     { configFileKeys::TIME_FORMAT, std::make_tuple(timeFormatPossibleValues, timeFormatPossibleValues.at("12")) },
-    { configFileKeys::WRITE_TO_LOG_FILE, std::make_tuple(writeToLogFilePossibleValues, writeToLogFilePossibleValues.at("enable")) },
+    { configFileKeys::WRITE_TO_LOG_FILE, std::make_tuple(writeToLogFilePossibleValues, writeToLogFilePossibleValues.at("ENABLE")) },
 };
 
 void getLoggingConfig(const std::filesystem::path& path) {

--- a/src/log_time.cpp
+++ b/src/log_time.cpp
@@ -114,15 +114,15 @@ std::function<std::string(std::string, const std::string, const std::string, con
 
 void updateMonthFunc() {
     std::cout << "Updating month function\n";
-    const rk::config::ActualValue monthFormat = std::get<1>(rk::config::configMap.at("month_format"));
-    if (monthFormat == std::get<0>(rk::config::configMap.at("month_format")).at("MONTH_NUM")) {
+    const rk::config::ActualValue monthFormat = std::get<1>(rk::config::configuration.at("month_format"));
+    if (monthFormat == std::get<0>(rk::config::configuration.at("month_format")).at("MONTH_NUM")) {
         monthFunc = [] (const int monthNum) {
             std::string month;
             month = std::to_string(monthNum);
             return month;
         };
     }
-    else if(monthFormat == std::get<0>(rk::config::configMap.at("month_format")).at("MONTH_NAME")) {
+    else if(monthFormat == std::get<0>(rk::config::configuration.at("month_format")).at("MONTH_NAME")) {
         monthFunc = [] (const int monthNum) {
             std::string month;
             month = monthNumToName(monthNum);
@@ -133,8 +133,8 @@ void updateMonthFunc() {
 
 void updateDateFunc() {
     std::cout << "Updating date function\n";
-    const rk::config::ActualValue dateFormat = std::get<1>(rk::config::configMap.at("date_format"));
-    if (dateFormat == std::get<0>(rk::config::configMap.at("date_format")).at("MM_DD_YYYY")) {
+    const rk::config::ActualValue dateFormat = std::get<1>(rk::config::configuration.at("date_format"));
+    if (dateFormat == std::get<0>(rk::config::configuration.at("date_format")).at("MM_DD_YYYY")) {
         dateFunc = [](const std::string year, const std::string month, const std::string day) {
             std::string timeStamp;
             timeStamp = "[" +
@@ -147,7 +147,7 @@ void updateDateFunc() {
             return timeStamp;
         };
     }
-    else if (dateFormat == std::get<0>(rk::config::configMap.at("date_format")).at("DD_MM_YYYY")) {
+    else if (dateFormat == std::get<0>(rk::config::configuration.at("date_format")).at("DD_MM_YYYY")) {
         dateFunc = [](const std::string year, const std::string month, const std::string day) {
             std::string timeStamp;
             timeStamp = "[" +
@@ -160,7 +160,7 @@ void updateDateFunc() {
             return timeStamp;
         };
     }
-    else if (dateFormat == std::get<0>(rk::config::configMap.at("date_format")).at("YYYY_MM_DD")) {
+    else if (dateFormat == std::get<0>(rk::config::configuration.at("date_format")).at("YYYY_MM_DD")) {
         dateFunc = [](const std::string year, const std::string month, const std::string day) {
             std::string timeStamp;
             timeStamp = "[" +
@@ -177,8 +177,8 @@ void updateDateFunc() {
 
 void updateTimeFunc() {
     std::cout << "Updating time function\n";
-    const rk::config::ActualValue timeFormat = std::get<1>(rk::config::configMap.at("time_format"));
-    if (timeFormat == std::get<0>(rk::config::configMap.at("time_format")).at("12")) {
+    const rk::config::ActualValue timeFormat = std::get<1>(rk::config::configuration.at("time_format"));
+    if (timeFormat == std::get<0>(rk::config::configuration.at("time_format")).at("12")) {
         timeFunc = [] (std::string hour, const std::string minute, const std::string second, const std::string millisecond) {
             int hourNum = std::stoi(hour);
             const bool isPM = (hourNum >= 12) ? true : false;
@@ -200,7 +200,7 @@ void updateTimeFunc() {
             return time;
         };
     }
-    else if(timeFormat == std::get<0>(rk::config::configMap.at("time_format")).at("24")) {
+    else if(timeFormat == std::get<0>(rk::config::configuration.at("time_format")).at("24")) {
         timeFunc = [] (std::string hour, const std::string minute, const std::string second, const std::string millisecond) {
             return hour + ":" + minute + ":" + second + "." + millisecond + "]";
         };
@@ -208,7 +208,7 @@ void updateTimeFunc() {
 }
 
 void updateTimeStampFuncs() {
-    std::cout << "Updating time stamp functions\n";
+    std::cout << "Updating timestamp functions\n";
     updateMonthFunc();
     updateDateFunc();
     updateTimeFunc();


### PR DESCRIPTION
…imestamp.

Added a `write to log file` config option. It will allow the user to either enable or disable writing logs to an output file.