### PR TITLE
Change uint8_t type to regular int

### DIFF
--- a/include/rk_logger/log_config.h
+++ b/include/rk_logger/log_config.h
@@ -16,7 +16,7 @@ namespace config {
 
 const inline std::string CONFIG_FILE_NAME = "rk_config.txt";
 
-using PossibleValuesMap = const std::unordered_map<std::string, uint8_t>;
+// Keys from the Config file
 namespace configFileKeys {
     const std::string DATE_FORMAT = "date_format";
     const std::string MONTH_FORMAT = "month_format";
@@ -24,13 +24,15 @@ namespace configFileKeys {
     const std::string WRITE_TO_LOG_FILE = "write_to_log_file";
 };
 
+using ConfigKey = std::string;
+using ConfigValue = int;
+using PossibleValuesMap = const std::unordered_map<ConfigKey, ConfigValue>;
 extern PossibleValuesMap dateFormatPossibleValues;
 extern PossibleValuesMap monthFormatPossibleValues;
 extern PossibleValuesMap timeFormatPossibleValues;
 extern PossibleValuesMap writeToLogFilePossibleValues;
 
-using ActualValue = uint8_t; /**< The type of value that will be used for the Config setting */
-using ConfigMap = std::unordered_map<std::string, std::tuple<PossibleValuesMap, ActualValue>>;
+using ConfigMap = std::unordered_map<std::string, std::tuple<PossibleValuesMap, ConfigValue>>;
 extern ConfigMap configuration; /**< Holds the current configuration */
 
 /**
@@ -49,7 +51,7 @@ void getLoggingConfig(const std::filesystem::path&);
  * @param ConfigMap::iterator An iterator to the key to be set.
  * @param std::string The value to set.
  */
-void updateConfigValue(const ConfigMap::iterator&, const ActualValue);
+void updateConfigValue(const ConfigMap::iterator&, const ConfigValue);
 
 } // namespace config
 } // namespace rk

--- a/include/rk_logger/log_time.h
+++ b/include/rk_logger/log_time.h
@@ -45,10 +45,10 @@ std::string generateTimeStamp(time_point);
  * 
  * It starts at 1 and goes up, so January = 1, February = 2, etc.
  * 
- * @brief The month number.
+ * @param int The month number.
  * @return The month's name abbreviated to the first 3 letters, e.g., Jan, Feb, etc.
  */
-std::string monthNumToName(const uint8_t);
+std::string monthNumToName(const int);
 
 /**
  * @brief Adds zeros to the beginning of a number to make it have a specific number of characters.

--- a/src/log_config.cpp
+++ b/src/log_config.cpp
@@ -10,28 +10,25 @@
 namespace rk {
 namespace config {
 
-// The values are explicitly casted to uint8_t in order to supress compiler warnings
 PossibleValuesMap dateFormatPossibleValues = {
-    { "MM_DD_YYYY", static_cast<uint8_t>(0u) }, // i.e., Feb 4, 2025 is formatted as [02|Feb]-04-2025
-    { "DD_MM_YYYY", static_cast<uint8_t>(1u) }, // i.e., Feb 4, 2025 is formatted as 04-[02|Feb]-2025
-    { "YYYY_MM_DD", static_cast<uint8_t>(2u) } // i.e., Feb 4, 2025 is formatted as 2025-[02|Feb]-04
+    { "MM_DD_YYYY", 0 }, // i.e., Feb 4, 2025 is formatted as [02|Feb]-04-2025
+    { "DD_MM_YYYY", 1 }, // i.e., Feb 4, 2025 is formatted as 04-[02|Feb]-2025
+    { "YYYY_MM_DD", 2 } // i.e., Feb 4, 2025 is formatted as 2025-[02|Feb]-04
 };
 
-// The values are explicitly casted to uint8_t in order to supress compiler warnings
 PossibleValuesMap monthFormatPossibleValues = {
-    { "MONTH_NUM", static_cast<uint8_t>(0u) }, // Prints the months name, e.g., Jan, Feb, etc.
-    { "MONTH_NAME", static_cast<uint8_t>(1u) } // Prints the month's number, e.g., 01, 02, etc.
+    { "MONTH_NUM", 0 }, // Prints the months name, e.g., Jan, Feb, etc.
+    { "MONTH_NAME", 1 } // Prints the month's number, e.g., 01, 02, etc.
 };
 
-// The values are explicitly casted to uint8_t in order to supress compiler warnings
 PossibleValuesMap timeFormatPossibleValues = {
-    { "12", static_cast<uint8_t>(0u) }, // Uses 12-hour clock format, e.g., 8:30PM becomes "08:30:00.000 PM"
-    { "24", static_cast<uint8_t>(1u) } // Uses 24-hour clock format, e.g., 8:30PM becomes "20:30:00.000"
+    { "12", 0 }, // Uses 12-hour clock format, e.g., 8:30PM becomes "08:30:00.000 PM"
+    { "24", 1 } // Uses 24-hour clock format, e.g., 8:30PM becomes "20:30:00.000"
 };
 
 PossibleValuesMap writeToLogFilePossibleValues = {
-    { "DISABLE", static_cast<uint8_t>(0) },
-    { "ENABLE", static_cast<uint8_t>(1) }
+    { "DISABLE", 0 },
+    { "ENABLE", 1 }
 };
 
 ConfigMap configuration = {
@@ -99,14 +96,14 @@ void getLoggingConfig(const std::filesystem::path& path) {
             continue;
         }
 
-        const ActualValue configValue = configValueIter->second;
+        const ConfigValue configValue = configValueIter->second;
         std::cout << "Updating config key \"" << configKey << "\" with value \"" << configValueStr << "\"" << std::endl;
         rk::config::updateConfigValue(configKeyIter, configValue);
     }
 }
 
-void updateConfigValue(const ConfigMap::iterator& configKeyIter, const ActualValue newValue) {
-    ActualValue& value =  std::get<1>(configKeyIter->second); // Access the current config's value
+void updateConfigValue(const ConfigMap::iterator& configKeyIter, const ConfigValue newValue) {
+    ConfigValue& value =  std::get<1>(configKeyIter->second); // Access the current config's value
     value = newValue;
 };
 

--- a/src/log_time.cpp
+++ b/src/log_time.cpp
@@ -57,7 +57,7 @@ std::string generateTimeStamp(time_point time_point) {
     return timeStamp;
 }
 
-std::string monthNumToName(const uint8_t monthNum) {
+std::string monthNumToName(const int monthNum) {
     if (monthNum < 1 || monthNum > 12) {
         return "N/A";
     }
@@ -114,7 +114,7 @@ std::function<std::string(std::string, const std::string, const std::string, con
 
 void updateMonthFunc() {
     std::cout << "Updating month function\n";
-    const rk::config::ActualValue monthFormat = std::get<1>(rk::config::configuration.at("month_format"));
+    const rk::config::ConfigValue monthFormat = std::get<1>(rk::config::configuration.at("month_format"));
     if (monthFormat == std::get<0>(rk::config::configuration.at("month_format")).at("MONTH_NUM")) {
         monthFunc = [] (const int monthNum) {
             std::string month;
@@ -133,7 +133,7 @@ void updateMonthFunc() {
 
 void updateDateFunc() {
     std::cout << "Updating date function\n";
-    const rk::config::ActualValue dateFormat = std::get<1>(rk::config::configuration.at("date_format"));
+    const rk::config::ConfigValue dateFormat = std::get<1>(rk::config::configuration.at("date_format"));
     if (dateFormat == std::get<0>(rk::config::configuration.at("date_format")).at("MM_DD_YYYY")) {
         dateFunc = [](const std::string year, const std::string month, const std::string day) {
             std::string timeStamp;
@@ -177,7 +177,7 @@ void updateDateFunc() {
 
 void updateTimeFunc() {
     std::cout << "Updating time function\n";
-    const rk::config::ActualValue timeFormat = std::get<1>(rk::config::configuration.at("time_format"));
+    const rk::config::ConfigValue timeFormat = std::get<1>(rk::config::configuration.at("time_format"));
     if (timeFormat == std::get<0>(rk::config::configuration.at("time_format")).at("12")) {
         timeFunc = [] (std::string hour, const std::string minute, const std::string second, const std::string millisecond) {
             int hourNum = std::stoi(hour);


### PR DESCRIPTION
Updated `uint8_t` type to regular `int` for simplicity's sake and performance reasons.