### PR TITLE
Convert Config to a class. Simplify config's key/value logic.

### DIFF
--- a/include/rk_logger/log_config.h
+++ b/include/rk_logger/log_config.h
@@ -14,57 +14,99 @@
 namespace rk {
 namespace config {
 
-const inline std::string CONFIG_FILE_NAME = "rk_config.txt";
+using ConfigKey = std::string;
+using ConfigValue = std::string;
+using ConfigMap = std::unordered_map<ConfigKey, ConfigValue>;
+using ValidValuesSet = std::unordered_set<ConfigValue>;
+using ValidKeyValuesMap = const std::unordered_map<ConfigKey, const ValidValuesSet>;
 
-// Keys from the Config file
-namespace configFileKeys {
-    const std::string DATE_FORMAT = "date_format";
-    const std::string MONTH_FORMAT = "month_format";
-    const std::string TIME_FORMAT = "time_format";
-    const std::string WRITE_TO_LOG_FILE = "write_to_log_file";
+extern const std::string CONFIG_FILE_NAME;
+
+namespace date_format {
+    extern const std::string KEY;
+    extern const std::string MM_DD_YYYY; // e.g., Feb 4, 2025 is formatted as [02|Feb]-04-2025
+    extern const std::string DD_MM_YYYY; // e.g., Feb 4, 2025 is formatted as 04-[02|Feb]-2025
+    extern const std::string YYYY_MM_DD; // e.g., Feb 4, 2025 is formatted as 2025-[02|Feb]-04
+}
+
+namespace month_format {
+    extern const std::string KEY;
+    extern const std::string MONTH_NUM; // Month as a name, e.g., Jan, Feb, etc.
+    extern const std::string MONTH_NAME; // Month as a number, e.g., 01, 02, etc.
+}
+
+namespace hour_format {
+    extern const std::string KEY;
+    extern const std::string TWELVE_HOUR; // 12-hour clock format, e.g., 8:30PM becomes "08:30:00.000 PM"
+    extern const std::string TWENTY_FOUR_HOUR; // 24-hour clock format, e.g., 8:30PM becomes "20:30:00.000"
+}
+
+namespace write_to_log_file {
+    extern const std::string KEY;
+    extern const std::string ENABLE;
+    extern const std::string DISABLE;
+}
+
+class Config {
+public:
+    Config() = delete;
+    Config(const Config&) = delete;
+    Config& operator=(const Config&) = delete;
+    friend Config& getInstance();
+
+    /**
+     * @brief Sets a value for a key/value pair in the Config.
+     * 
+     * @param ConfigKey The key to change the value for.
+     * @param ConfigValue The value to change it to.
+     */
+    void setConfigValue(const ConfigKey, const ConfigValue);
+
+    /**
+     * @brief Gets the current config's value for a given key.
+     * 
+     * @param ConfigKey The key.
+     * @return The corresponding value.
+     */
+    ConfigValue getConfigValueByKey(const ConfigKey) const;
+
+    /**
+     * @brief Parses the logging config file and updates the settings based on the contents.
+     * 
+     * @param path The path to the config file including the file name itself. The default path is the same directory as the executable.
+     */
+    void parseLoggingConfig(const std::filesystem::path&);
+
+    /**
+     * @brief Checks if a key is valid.
+     * 
+     * @param ConfigKey The key to check.
+     * @return True if key is valid, false otherwise.
+     */
+    bool isKeyValid(const ConfigKey) const;
+
+    /**
+     * @brief Checks if both a key and value are valid.
+     * 
+     * @param ConfigKey The key to check.
+     * @param ConfigValue The corresponding value to check.
+     * @return True if both key and value are valid, false otherwise.
+     */
+    bool isKeyAndValueValid(const ConfigKey, const ConfigValue) const;
+
+private:
+    Config(ConfigMap&& defaultConfig, ValidKeyValuesMap&& keyValues) : config(std::move(defaultConfig)), validKeyValues(std::move(keyValues)) {};
+
+    ConfigMap config;
+    ValidKeyValuesMap validKeyValues;
 };
 
-using ConfigKey = std::string;
-using ConfigValue = int;
-using PossibleValuesMap = const std::unordered_map<ConfigKey, ConfigValue>;
-extern PossibleValuesMap dateFormatPossibleValues;
-extern PossibleValuesMap monthFormatPossibleValues;
-extern PossibleValuesMap timeFormatPossibleValues;
-extern PossibleValuesMap writeToLogFilePossibleValues;
-
-using ConfigMap = std::unordered_map<std::string, std::tuple<PossibleValuesMap, ConfigValue>>;
-// Indices for the data that a key maps to
-namespace ConfigMapIndices {
-    constexpr int POSSIBLE_VALUES = 0;
-    constexpr int CONFIG_VALUE = 1;
-}
-extern ConfigMap configuration; /**< Holds the current configuration */
-
 /**
- * @brief Parses the logging config file and updates the settings based on the contents.
+ * @brief Gets the instance of the config class.
  * 
- * If no config file is provided, then it will just use the default settings.
- * 
- * @param path The path to the config file including the file name itself. The default path is the same directory as the executable.
- * Override it by providing a custom path.
+ * @return The instance.
  */
-void getLoggingConfig(const std::filesystem::path&);
-
-/**
- * @brief Gets the current config's value for a given key.
- * 
- * @param std::string The key.
- * @return The corresponding value.
- */
-ConfigValue getConfigValueByKey(const std::string);
-
-/**
- * @brief Updates the config map with the values provided.
- * 
- * @param ConfigMap::iterator An iterator to the key to be set.
- * @param std::string The value to set.
- */
-void updateConfigValue(const ConfigMap::iterator&, const ConfigValue);
+Config& getInstance();
 
 } // namespace config
 } // namespace rk

--- a/src/demonstration/rk_config.txt
+++ b/src/demonstration/rk_config.txt
@@ -28,15 +28,15 @@ date_format=MM_DD_YYYY
 month_format=MONTH_NUM
 
 /**
- * TIME FORMAT
+ * HOUR FORMAT
  * 
- * Sets the time format to be either 12-hour or 24-hour format.
+ * Sets the hour format to be either 12-hour or 24-hour format.
  *
  * Possible values:
  * "12" e.g., 8:30PM becomes "08:30:00.000 PM"
  * "24" e.g., 8:30PM becomes "20:30:00.000"
  */
-time_format=12
+hour_format=12
 
 /**
  * WRITE TO LOG FILE

--- a/src/log_time.cpp
+++ b/src/log_time.cpp
@@ -2,6 +2,8 @@
  * @file log_time.cpp
  * @brief Source file for code related to time for logs.
  */
+#define RK_TIME_LOG(...) std::cout << "[RKLogger Time] " << __VA_ARGS__
+
 #include <iomanip>
 #include <iostream>
 
@@ -113,16 +115,16 @@ std::function<std::string(const std::string, const std::string, const std::strin
 std::function<std::string(std::string, const std::string, const std::string, const std::string)> timeFunc = nullptr;
 
 void updateMonthFunc() {
-    std::cout << "Updating month function\n";
-    const rk::config::ConfigValue monthFormat = rk::config::getConfigValueByKey(rk::config::configFileKeys::MONTH_FORMAT);
-    if (monthFormat == std::get<0>(rk::config::configuration.at("month_format")).at("MONTH_NUM")) {
+    RK_TIME_LOG("Updating month function\n");
+    const rk::config::ConfigValue monthFormat = rk::config::getInstance().getConfigValueByKey(rk::config::month_format::KEY);
+    if (monthFormat == rk::config::month_format::MONTH_NUM) {
         monthFunc = [] (const int monthNum) {
             std::string month;
             month = std::to_string(monthNum);
             return month;
         };
     }
-    else if(monthFormat == std::get<0>(rk::config::configuration.at("month_format")).at("MONTH_NAME")) {
+    else if(monthFormat == rk::config::month_format::MONTH_NAME) {
         monthFunc = [] (const int monthNum) {
             std::string month;
             month = monthNumToName(monthNum);
@@ -132,53 +134,53 @@ void updateMonthFunc() {
 }
 
 void updateDateFunc() {
-    std::cout << "Updating date function\n";
-    const rk::config::ConfigValue dateFormat = rk::config::getConfigValueByKey(rk::config::configFileKeys::DATE_FORMAT);
-    if (dateFormat == std::get<0>(rk::config::configuration.at("date_format")).at("MM_DD_YYYY")) {
+    RK_TIME_LOG("Updating date function\n");
+    const rk::config::ConfigValue dateFormat = rk::config::getInstance().getConfigValueByKey(rk::config::date_format::KEY);
+    if (dateFormat == rk::config::date_format::MM_DD_YYYY) {
         dateFunc = [](const std::string year, const std::string month, const std::string day) {
-            std::string timeStamp;
-            timeStamp = "[" +
+            std::string date;
+            date = "[" +
                         month +
                         "-" +
                         day +
                         "-" +
                         year +
                         "|";
-            return timeStamp;
+            return date;
         };
     }
-    else if (dateFormat == std::get<0>(rk::config::configuration.at("date_format")).at("DD_MM_YYYY")) {
+    else if (dateFormat == rk::config::date_format::DD_MM_YYYY) {
         dateFunc = [](const std::string year, const std::string month, const std::string day) {
-            std::string timeStamp;
-            timeStamp = "[" +
+            std::string date;
+            date = "[" +
                         day +
                         "-" +
                         month +
                         "-" +
                         year +
                         "|";
-            return timeStamp;
+            return date;
         };
     }
-    else if (dateFormat == std::get<0>(rk::config::configuration.at("date_format")).at("YYYY_MM_DD")) {
+    else if (dateFormat == rk::config::date_format::YYYY_MM_DD) {
         dateFunc = [](const std::string year, const std::string month, const std::string day) {
-            std::string timeStamp;
-            timeStamp = "[" +
+            std::string date;
+            date = "[" +
                         year +
                         "-" +
                         month +
                         "-" +
                         day +
                         "|";
-            return timeStamp;
+            return date;
         };
     }
 }
 
 void updateTimeFunc() {
-    std::cout << "Updating time function\n";
-    const rk::config::ConfigValue timeFormat = rk::config::getConfigValueByKey(rk::config::configFileKeys::TIME_FORMAT);
-    if (timeFormat == std::get<0>(rk::config::configuration.at("time_format")).at("12")) {
+    RK_TIME_LOG("Updating time function\n");
+    const rk::config::ConfigValue hourFormat = rk::config::getInstance().getConfigValueByKey(rk::config::hour_format::KEY);
+    if (hourFormat == rk::config::hour_format::TWELVE_HOUR) {
         timeFunc = [] (std::string hour, const std::string minute, const std::string second, const std::string millisecond) {
             int hourNum = std::stoi(hour);
             const bool isPM = (hourNum >= 12) ? true : false;
@@ -190,17 +192,17 @@ void updateTimeFunc() {
 
             std::string time = hour + ":" + minute + ":" + second + "." + millisecond;
             if (isPM) {
-                time = time + " PM";
+                time += " PM";
             }
             else {
-                time = time + " AM";
+                time += " AM";
             }
-            time = time + "]";
+            time += "]";
 
             return time;
         };
     }
-    else if(timeFormat == std::get<0>(rk::config::configuration.at("time_format")).at("24")) {
+    else if(hourFormat == rk::config::hour_format::TWENTY_FOUR_HOUR) {
         timeFunc = [] (std::string hour, const std::string minute, const std::string second, const std::string millisecond) {
             return hour + ":" + minute + ":" + second + "." + millisecond + "]";
         };
@@ -208,7 +210,7 @@ void updateTimeFunc() {
 }
 
 void updateTimeStampFuncs() {
-    std::cout << "Updating timestamp functions\n";
+    RK_TIME_LOG("Updating timestamp functions\n");
     updateMonthFunc();
     updateDateFunc();
     updateTimeFunc();

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -16,10 +16,10 @@ std::condition_variable cv;
 
 std::thread startLogger(const std::filesystem::path& configPath) {
     // Read config settings from a file (if it exists) and update the internal config
-    rk::config::getLoggingConfig(configPath);
+    rk::config::getInstance().parseLoggingConfig(configPath);
     rk::time::updateTimeStampFuncs();
 
-    if (rk::config::getConfigValueByKey(rk::config::configFileKeys::WRITE_TO_LOG_FILE)) {
+    if (rk::config::getInstance().getConfigValueByKey(rk::config::write_to_log_file::KEY) == rk::config::write_to_log_file::ENABLE) {
         openLogFile();
     }
 
@@ -31,7 +31,7 @@ std::thread startLogger(const std::filesystem::path& configPath) {
 
 void stopLogger(std::thread logThread) {
     endLogThread(std::move(logThread));
-    if (rk::config::getConfigValueByKey(rk::config::configFileKeys::WRITE_TO_LOG_FILE)) {
+    if (rk::config::getInstance().getConfigValueByKey(rk::config::write_to_log_file::KEY) == rk::config::write_to_log_file::ENABLE) {
         closeLogFile();
     }
 }


### PR DESCRIPTION
*  Converted the config code to a `Config` class.
* Added constants for the key/value pairs.
* Updated `Value` type to be std::string.
* Simplified overall key/value logic.