### PR TITLE
Decrease loss of logs on exception

### DIFF
--- a/include/rk_logger/logger.h
+++ b/include/rk_logger/logger.h
@@ -129,6 +129,11 @@ void verifyLogFile();
 void enableAutoFlush();
 
 /**
+ * @brief Disables automatic flushing of the std::cout output stream.
+ */
+void disableAutoFlush();
+
+/**
  * @brief Prints an internal log message for the main logging module.
  * 
  * @param args The message to print.

--- a/include/rk_logger/logger.h
+++ b/include/rk_logger/logger.h
@@ -124,6 +124,11 @@ void closeLogFile();
 void verifyLogFile();
 
 /**
+ * @brief Enables automatic flushing of the std::cout output stream.
+ */
+void enableAutoFlush();
+
+/**
  * @brief Prints an internal log message for the main logging module.
  * 
  * @param args The message to print.

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -20,6 +20,7 @@ std::thread startLogger(const std::filesystem::path& configPath) {
         rk::log_internal::verifyLogFile();
     }
 
+    rk::log_internal::enableAutoFlush();
     std::thread logThread = rk::log_internal::startLogThread();
 
     return logThread;
@@ -73,6 +74,7 @@ void logQueueLoop() {
                 std::cout << msg;
                 if (logFile) {
                     logFile << msg;
+                    logFile.flush();
                 }
                 msg.clear();
             }
@@ -128,6 +130,10 @@ void verifyLogFile() {
         rkLogInternal("Unable to open output log file\n");
         throw -1;
     }
+}
+
+void enableAutoFlush() {
+    std::cout << std::unitbuf;
 }
 
 } // namespace log_internal

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -29,6 +29,7 @@ std::thread startLogger(const std::filesystem::path& configPath) {
 void stopLogger(std::thread logThread) {
     rk::log_internal::rkLogInternal("Stopping RK Logger\n");
     rk::log_internal::endLogThread(std::move(logThread));
+    rk::log_internal::disableAutoFlush();
     if (rk::config::getInstance().getConfigValueByKey(rk::config::write_to_log_file::KEY) == rk::config::write_to_log_file::ENABLE) {
         rk::log_internal::closeLogFile();
     }
@@ -134,6 +135,10 @@ void verifyLogFile() {
 
 void enableAutoFlush() {
     std::cout << std::unitbuf;
+}
+
+void disableAutoFlush() {
+    std::cout << std::nounitbuf;
 }
 
 } // namespace log_internal


### PR DESCRIPTION
* Added explicit flushes after std::ofstream insertions to decrease loss of logs on exception.
* Similarly, for std::cout, added function to enable automatic flushing.
* Added function to disable as well.